### PR TITLE
[Feat] #54 - nickname 중복체크 API 구현 

### DIFF
--- a/src/main/java/com/pophory/pophoryserver/domain/member/MemberController.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/MemberController.java
@@ -1,8 +1,10 @@
 package com.pophory.pophoryserver.domain.member;
 
 import com.pophory.pophoryserver.domain.member.dto.request.MemberCreateRequestDto;
+import com.pophory.pophoryserver.domain.member.dto.request.MemberNicknameDuplicateRequestDto;
 import com.pophory.pophoryserver.domain.member.dto.response.MemberGetResponseDto;
 import com.pophory.pophoryserver.domain.member.dto.response.MemberMyPageGetResponseDto;
+import com.pophory.pophoryserver.domain.member.dto.response.MemberNicknameDuplicateResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -61,5 +63,17 @@ public class MemberController {
     )
     public ResponseEntity<MemberGetResponseDto> getMember(Principal principal) {
         return ResponseEntity.ok(memberService.getMember(getMemberId(principal)));
+    }
+
+    @PostMapping
+    @Operation(summary = "멤버 아이디 중복 조회 API")
+    @ApiResponses( value = {
+            @ApiResponse(responseCode = "204", description = "아이디 중복 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "사용자 정보 조회 실패", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    }
+    )
+    public ResponseEntity<MemberNicknameDuplicateResponseDto> postMemberNickname(@Valid @RequestBody MemberNicknameDuplicateRequestDto memberNicknameDuplicateRequestDto) {
+        return ResponseEntity.ok(memberService.checkDuplicateMemberNickname(memberNicknameDuplicateRequestDto.getNickname()));
     }
 }

--- a/src/main/java/com/pophory/pophoryserver/domain/member/MemberController.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/MemberController.java
@@ -68,7 +68,7 @@ public class MemberController {
     @PostMapping
     @Operation(summary = "멤버 아이디 중복 조회 API")
     @ApiResponses( value = {
-            @ApiResponse(responseCode = "204", description = "아이디 중복 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "아이디 중복 조회 성공"),
             @ApiResponse(responseCode = "400", description = "사용자 정보 조회 실패", content = @Content),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
     }

--- a/src/main/java/com/pophory/pophoryserver/domain/member/MemberService.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/MemberService.java
@@ -5,6 +5,7 @@ import com.pophory.pophoryserver.domain.album.AlbumJpaRepository;
 import com.pophory.pophoryserver.domain.member.dto.request.MemberCreateRequestDto;
 import com.pophory.pophoryserver.domain.member.dto.response.MemberGetResponseDto;
 import com.pophory.pophoryserver.domain.member.dto.response.MemberMyPageGetResponseDto;
+import com.pophory.pophoryserver.domain.member.dto.response.MemberNicknameDuplicateResponseDto;
 import com.pophory.pophoryserver.domain.photo.Photo;
 import com.pophory.pophoryserver.domain.photo.dto.response.PhotoGetResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,11 @@ public class MemberService {
         return MemberMyPageGetResponseDto.of(
                 findMemberById(memberId), getPhotoCount(memberId), getPhotos(memberId)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public MemberNicknameDuplicateResponseDto checkDuplicateMemberNickname(String nickname) {
+        return MemberNicknameDuplicateResponseDto.of(memberJpaRepository.existsMemberByNickname(nickname));
     }
 
     private void updateMemberInfo(MemberCreateRequestDto request, Long memberId) {

--- a/src/main/java/com/pophory/pophoryserver/domain/member/dto/request/MemberNicknameDuplicateRequestDto.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/dto/request/MemberNicknameDuplicateRequestDto.java
@@ -1,0 +1,28 @@
+package com.pophory.pophoryserver.domain.member.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@Schema(description = "회원 아이디 중복 확인 요청 DTO")
+public class MemberNicknameDuplicateRequestDto {
+
+    @NotBlank
+    @Size(min = 4, max = 12)
+    @Pattern(regexp = "^[a-zA-Z0-9_]*$")
+    @Schema(description = "회원 아이디", example = "pophory")
+    private String nickname;
+
+    @JsonCreator
+    private MemberNicknameDuplicateRequestDto(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/pophory/pophoryserver/domain/member/dto/response/MemberNicknameDuplicateResponseDto.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/dto/response/MemberNicknameDuplicateResponseDto.java
@@ -1,0 +1,20 @@
+package com.pophory.pophoryserver.domain.member.dto.response;
+
+import com.pophory.pophoryserver.domain.member.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "회원 아이디 중복 여부")
+public class MemberNicknameDuplicateResponseDto {
+    @Schema(description = "회원 아이디 중복 여부", example = "false")
+    private Boolean isDuplicated;
+
+    public static MemberNicknameDuplicateResponseDto of(Boolean isDuplicated) {
+        return new MemberNicknameDuplicateResponseDto(isDuplicated);
+    }
+}


### PR DESCRIPTION
## 🍃 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- Resolved: #54

## 🌱 변경사항
- 멤버 아이디 중복체크 API를 구현했습니다.

## 🌷 참고사항
<img width="700" alt="image" src="https://github.com/TeamPophory/pophory-server/assets/65678579/46092277-704b-4db9-92d2-4143f5212c0b">
