### PR TITLE
[fix #58] 앨범 내 사진 조회 정렬 추가

### DIFF
--- a/src/main/java/com/pophory/pophoryserver/domain/album/AlbumService.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/album/AlbumService.java
@@ -3,6 +3,7 @@ package com.pophory.pophoryserver.domain.album;
 
 import com.pophory.pophoryserver.domain.album.dto.response.AlbumGetResponseDto;
 import com.pophory.pophoryserver.domain.album.dto.response.AlbumListGetResponseDto;
+import com.pophory.pophoryserver.domain.photo.Photo;
 import com.pophory.pophoryserver.domain.photo.PhotoJpaRepository;
 import com.pophory.pophoryserver.domain.photo.dto.response.PhotoGetResponseDto;
 import com.pophory.pophoryserver.domain.photo.dto.response.PhotoListGetResponseDto;
@@ -11,6 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,9 +35,12 @@ public class AlbumService {
 
     @Transactional(readOnly = true)
     public PhotoListGetResponseDto getPhotosByAlbum(Long albumId, Long memberId) {
+        List<Photo> photos = new ArrayList<>();
         return PhotoListGetResponseDto.of(
                 photoJpaRepository.findAllByAlbum(getAlbumById(albumId))
                         .stream()
+                        .sorted(Comparator.comparing(Photo::getTakenAt)
+                                .thenComparing(Photo::getCreatedAt))
                         .map(PhotoGetResponseDto::of)
                         .collect(Collectors.toList())
         );


### PR DESCRIPTION
## 🍃 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- Resolved: #58

## 🌱 변경사항
- 앨범 내 사진 목록 조회 시 takenAt -> createdAt 순으로 조회

## 🌷 참고사항
<img width="1004" alt="image" src="https://github.com/TeamPophory/pophory-server/assets/65678579/aadcd443-1a2a-4b5d-ae9c-2f50fb2368bc">
