### PR TITLE
[hotfix #129] 앨범 로직 수정

### DIFF
--- a/src/main/java/com/pophory/pophoryserver/domain/album/Album.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/album/Album.java
@@ -1,6 +1,7 @@
 package com.pophory.pophoryserver.domain.album;
 
 import com.pophory.pophoryserver.domain.albumtheme.AlbumCover;
+import com.pophory.pophoryserver.domain.albumtheme.AlbumDesign;
 import com.pophory.pophoryserver.domain.member.Member;
 import com.pophory.pophoryserver.domain.photo.Photo;
 import com.pophory.pophoryserver.global.entity.BaseTimeEntity;
@@ -24,9 +25,9 @@ public class Album extends BaseTimeEntity {
 
     private String title = "기본 앨범";
 
-    @JoinColumn(name = "album_cover_id")
+    @JoinColumn(name = "album_design_id")
     @OneToOne(fetch = LAZY)
-    private AlbumCover albumCover;
+    private AlbumDesign albumDesign;
 
     private int photoLimit;
 
@@ -47,8 +48,8 @@ public class Album extends BaseTimeEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
-    public void setCover(AlbumCover albumCover) {
-        this.albumCover = albumCover;
+    public void setAlbumDesign(AlbumDesign albumDesign) {
+        this.albumDesign = albumDesign;
     }
     public void setMember(Member member) { this.member = member; }
 

--- a/src/main/java/com/pophory/pophoryserver/domain/album/dto/response/AlbumGetResponseDto.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/album/dto/response/AlbumGetResponseDto.java
@@ -13,12 +13,12 @@ public class AlbumGetResponseDto {
     private Long id;
     @Schema(description = "앨범 제목", example = "강윤서의 앨범")
     private String title;
-    @Schema(description = "앨범 커버", example = "1")
-    private int albumCover;
+    @Schema(description = "앨범 디자인", example = "1")
+    private Long albumDesignId;
     @Schema(description = "앨범 사진 수", example = "3")
     private int photoCount;
 
     public static AlbumGetResponseDto of(Album album, int count) {
-        return new AlbumGetResponseDto(album.getId(), album.getTitle(), album.getAlbumCover().getCoverNumber(),count);
+        return new AlbumGetResponseDto(album.getId(), album.getTitle(), album.getAlbumDesign().getId(), count);
     }
 }

--- a/src/main/java/com/pophory/pophoryserver/domain/album/dto/response/AlbumGetV2ResponseDto.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/album/dto/response/AlbumGetV2ResponseDto.java
@@ -13,14 +13,14 @@ public class AlbumGetV2ResponseDto {
     private Long id;
     @Schema(description = "앨범 제목", example = "강윤서의 앨범")
     private String title;
-    @Schema(description = "앨범 커버", example = "1")
-    private int albumCover;
+    @Schema(description = "앨범 디자인", example = "1")
+    private Long albumDesignId;
     @Schema(description = "앨범 사진 수", example = "3")
     private int photoCount;
     @Schema(description = "앨범 사진 한도", example = "15")
     private int photoLimit;
 
     public static AlbumGetV2ResponseDto of(Album album, int count) {
-        return new AlbumGetV2ResponseDto(album.getId(), album.getTitle(), album.getAlbumCover().getCoverNumber(),count, album.getPhotoLimit());
+        return new AlbumGetV2ResponseDto(album.getId(), album.getTitle(), album.getAlbumDesign().getId(), count, album.getPhotoLimit());
     }
 }

--- a/src/main/java/com/pophory/pophoryserver/domain/albumtheme/AlbumDesign.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/albumtheme/AlbumDesign.java
@@ -14,7 +14,7 @@ public class AlbumDesign {
     @Id @GeneratedValue
     private Long id;
 
-    @JoinColumn(name = "album_id")
+    @JoinColumn(name = "album_cover_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private AlbumCover albumCover;
 

--- a/src/main/java/com/pophory/pophoryserver/domain/member/MemberService.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/MemberService.java
@@ -4,6 +4,8 @@ import com.pophory.pophoryserver.domain.album.Album;
 import com.pophory.pophoryserver.domain.album.repository.AlbumJpaRepository;
 import com.pophory.pophoryserver.domain.albumtheme.AlbumCover;
 import com.pophory.pophoryserver.domain.albumtheme.AlbumCoverJpaRepository;
+import com.pophory.pophoryserver.domain.albumtheme.AlbumDesign;
+import com.pophory.pophoryserver.domain.albumtheme.AlbumDesignJpaRepository;
 import com.pophory.pophoryserver.domain.fcm.FcmEntity;
 import com.pophory.pophoryserver.domain.fcm.FcmJpaRepository;
 import com.pophory.pophoryserver.domain.fcm.FcmOS;
@@ -30,7 +32,7 @@ public class MemberService {
 
     private final MemberJpaRepository memberJpaRepository;
     private final AlbumJpaRepository albumJpaRepository;
-    private final AlbumCoverJpaRepository albumCoverJpaRepository;
+    private final AlbumDesignJpaRepository albumDesignJpaRepository;
     private final FcmJpaRepository fcmJpaRepository;
 
     private static final int INITIAL_PHOTO_LIMIT = 15;
@@ -106,25 +108,17 @@ public class MemberService {
         );
     }
 
-    private void addAlbum(Member member, int cover) {
+    private void addAlbum(Member member, Long cover) {
         Album album = new Album();
-        AlbumCover albumCover = AlbumCover.builder()
-                .coverNumber(cover)
-                .build();
-        albumCoverJpaRepository.save(albumCover);
-        album.setCover(albumCover);
+        album.setAlbumDesign(getAlbumDesignById(cover));
         album.setMember(member);
         album.setPhotoLimit(INITIAL_PHOTO_LIMIT);
         albumJpaRepository.save(album);
     }
 
-    private Long addAlbumV2(Member member, int cover) {
+    private Long addAlbumV2(Member member, Long cover) {
         Album album = new Album();
-        AlbumCover albumCover = AlbumCover.builder()
-                .coverNumber(cover)
-                .build();
-        albumCoverJpaRepository.save(albumCover);
-        album.setCover(albumCover);
+        album.setAlbumDesign(getAlbumDesignById(cover));
         album.setMember(member);
         album.setPhotoLimit(INITIAL_PHOTO_LIMIT);
         albumJpaRepository.save(album);
@@ -145,6 +139,12 @@ public class MemberService {
                 album -> album.getPhotoList().size())
                 .mapToInt(Integer::intValue)
                 .sum();
+    }
+
+    private AlbumDesign getAlbumDesignById(Long albumDesignId) {
+        return albumDesignJpaRepository.findById(albumDesignId).orElseThrow(
+                () -> new EntityNotFoundException("해당 앨범 디자인이 존재하지 않습니다. id:" + albumDesignId)
+        );
     }
 
     private List<PhotoGetResponseDto> getPhotos(Long memberId) {

--- a/src/main/java/com/pophory/pophoryserver/domain/member/dto/request/MemberCreateRequestDto.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/dto/request/MemberCreateRequestDto.java
@@ -27,5 +27,5 @@ public class MemberCreateRequestDto {
     private String nickname;
 
     @Schema(description = "앨범 커버 1 ~ 4 중의 값으로 요청", example = "1")
-    private int albumCover;
+    private Long albumCover;
 }

--- a/src/main/java/com/pophory/pophoryserver/domain/member/dto/request/MemberCreateV2RequestDto.java
+++ b/src/main/java/com/pophory/pophoryserver/domain/member/dto/request/MemberCreateV2RequestDto.java
@@ -28,7 +28,7 @@ public class MemberCreateV2RequestDto {
     private String nickname;
 
     @Schema(description = "앨범 커버 1 ~ 4 중의 값으로 요청", example = "1")
-    private int albumCover;
+    private Long albumCover;
 
     @Schema(description = "멤버의 fcmToken")
     private String fcmToken;

--- a/src/main/java/com/pophory/pophoryserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/pophory/pophoryserver/global/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
             "/actuator/**",
             "/api/v2/push/test/no-auth",
             "/api/v2/share/**",
-            "/semver"
+            "/version"
     };
 
     private static final String[] SWAGGER_URL = {


### PR DESCRIPTION
## 🍃 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- Resolved: #129 

## 🌱 변경사항
- album이 albumCover 대신 albumDesign 참조하도록 수정
- 컬럼명 수정
- 회원가입 정보 입력 시 앨범 커버를 새로 생성하지 않고 album에 albumDesign값을 update하도록 수정

## 🌷 참고사항
- reqeustDto의 albumCover명은 albumDesign으로 수정하지 않았습니다.
